### PR TITLE
Restore MINGW hack that was in ExtUtils::Depends < 0.8001

### DIFF
--- a/lib/Orbital/Payload/Environment/Perl/System/MSWin32/EUMMnosearch.pm
+++ b/lib/Orbital/Payload/Environment/Perl/System/MSWin32/EUMMnosearch.pm
@@ -3,9 +3,11 @@ use warnings;
 package Orbital::Payload::Environment::Perl::System::MSWin32::EUMMnosearch;
 # ABSTRACT: Hack ExtUtils::MakeMaker library searching on MSWin32
 
-package main;
+package # hide from PAUSE
+	main;
 # only run when we call the Makefile.PL script
 if( $0 eq "Makefile.PL" || $0 eq "./Makefile.PL"  ) {
+	$0 = "./Makefile.PL"; # normalise for no '.' in @INC
 	require ExtUtils::MakeMaker;
 	require ExtUtils::Liblist::Kid;
 


### PR DESCRIPTION
- Restore MINGW hack that was in ExtUtils::Depends < 0.8001
- Win32: make CPAN client working directory short
